### PR TITLE
[MAASENG-4204] Re-Use Image selection form for MAAS-UI

### DIFF
--- a/src/app/images/components/ImagesForms/ImagesForms.tsx
+++ b/src/app/images/components/ImagesForms/ImagesForms.tsx
@@ -3,6 +3,7 @@ import { useCallback } from "react";
 import DeleteImageConfirm from "../ImagesTable/DeleteImageConfirm";
 
 import type { SidePanelContentTypes } from "@/app/base/side-panel-context";
+import DownloadImages from "@/app/images/components/SMImagesTable/DownloadImages/DownloadImages";
 import { ImageSidePanelViews } from "@/app/images/constants";
 import ChangeSource from "@/app/images/views/ImageList/SyncedImages/ChangeSource";
 
@@ -46,6 +47,9 @@ const ImagesForms = ({
           resource={bootResource}
         />
       );
+    }
+    case ImageSidePanelViews.DOWNLOAD_IMAGE: {
+      return <DownloadImages />;
     }
     default:
       return null;

--- a/src/app/images/components/SMImagesTable/DownloadImages/DownloadImages.tsx
+++ b/src/app/images/components/SMImagesTable/DownloadImages/DownloadImages.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useEffect, useState } from "react";
 
 import type { MultiSelectItem } from "@canonical/react-components";
-import { MultiSelect, Form, Strip } from "@canonical/react-components";
-import { Field } from "formik";
+import { Strip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import FormikForm from "@/app/base/components/FormikForm";
 import { useSidePanel } from "@/app/base/side-panel-context";
+import DownloadImagesSelect from "@/app/images/components/SMImagesTable/DownloadImages/DownloadImagesSelect";
 import { bootResourceActions } from "@/app/store/bootresource";
 import bootResourceSelectors from "@/app/store/bootresource/selectors";
 import type {
@@ -21,7 +21,7 @@ import {
 
 import "./_index.scss";
 
-type GroupedImages = {
+export type GroupedImages = {
   [key: string]: ReleasesWithArches;
 };
 
@@ -130,9 +130,6 @@ const groupArchesByRelease = (images: ImagesByOS) => {
   return groupedImages;
 };
 
-const getValueKey = (distro: string, release: string) =>
-  `${distro}-${release}`.replace(".", "-");
-
 const DownloadImages: React.FC = () => {
   const dispatch = useDispatch();
   const ubuntu = useSelector(bootResourceSelectors.ubuntu);
@@ -221,41 +218,11 @@ const DownloadImages: React.FC = () => {
         submitLabel={"Download"}
       >
         {({ values, setFieldValue }: { values: any; setFieldValue: any }) => (
-          <Form>
-            {Object.keys(groupedImages).map((distro) => (
-              <span key={distro}>
-                <h2 className="p-heading--4">{distro} images</h2>
-                <table className="download-images-table">
-                  <thead>
-                    <tr>
-                      <th>Release</th>
-                      <th>Architecture</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {Object.keys(groupedImages[distro]).map((release) => (
-                      <tr aria-label={release} key={release}>
-                        <td>{release}</td>
-                        <td>
-                          <Field
-                            as={MultiSelect}
-                            items={groupedImages[distro][release]}
-                            name={`${distro}-${release}`}
-                            onItemsUpdate={(items: MultiSelectItem) =>
-                              setFieldValue(getValueKey(distro, release), items)
-                            }
-                            placeholder="Select architectures"
-                            selectedItems={values[getValueKey(distro, release)]}
-                            variant="condensed"
-                          />
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </span>
-            ))}
-          </Form>
+          <DownloadImagesSelect
+            groupedImages={groupedImages}
+            setFieldValue={setFieldValue}
+            values={values}
+          />
         )}
       </FormikForm>
     </Strip>

--- a/src/app/images/components/SMImagesTable/DownloadImages/DownloadImages.tsx
+++ b/src/app/images/components/SMImagesTable/DownloadImages/DownloadImages.tsx
@@ -1,22 +1,22 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 
-import { ContentSection } from "@canonical/maas-react-components";
 import type { MultiSelectItem } from "@canonical/react-components";
-import {
-  MultiSelect,
-  ActionButton,
-  Button,
-  Form,
-} from "@canonical/react-components";
-import { Field, Formik } from "formik";
+import { MultiSelect, Form, Strip } from "@canonical/react-components";
+import { Field } from "formik";
 import { useDispatch, useSelector } from "react-redux";
 
+import FormikForm from "@/app/base/components/FormikForm";
 import { useSidePanel } from "@/app/base/side-panel-context";
 import { bootResourceActions } from "@/app/store/bootresource";
 import bootResourceSelectors from "@/app/store/bootresource/selectors";
 import type {
+  BootResource,
   BootResourceUbuntuArch,
   BootResourceUbuntuRelease,
+} from "@/app/store/bootresource/types";
+import {
+  BootResourceSourceType,
+  BootResourceAction,
 } from "@/app/store/bootresource/types";
 
 import "./_index.scss";
@@ -29,13 +29,14 @@ type ReleasesWithArches = {
   [key: string]: MultiSelectItem[];
 };
 
-type ImagesByName = { [key: string]: DownloadableImage[] };
+type ImagesByOS = { [key: string]: DownloadableImage[] };
 
 type DownloadableImage = {
   id: string;
   name: string;
   release: string;
   architectures: string;
+  os: string;
 };
 
 const getDownloadableImages = (
@@ -46,37 +47,66 @@ const getDownloadableImages = (
     .map((image) => {
       return architectures.map((arch) => {
         return {
-          id: `ubuntu-${image.title}-${arch.name}`,
-          name: "Ubuntu",
+          id: `ubuntu-${image.name}-${image.title}-${arch.name}`,
+          name: image.name,
           release: image.title,
           architectures: arch.name,
+          os: "Ubuntu",
         };
       });
     })
     .flat();
 };
 
-const groupImagesByName = (images: DownloadableImage[]) => {
-  let imagesByName: ImagesByName = {};
+const getSyncedImages = (
+  downloadableImages: DownloadableImage[],
+  resources: BootResource[]
+): Record<string, { label: string; value: string }[]> => {
+  return downloadableImages
+    .filter((image) => {
+      return resources.some(
+        (resource) =>
+          resource.title === image.release &&
+          resource.arch === image.architectures
+      );
+    })
+    .reduce<Record<string, { label: string; value: string }[]>>(
+      (acc, image) => {
+        const key = `${image.os}-${image.release.replace(".", "-")}`;
+        if (!acc[key]) {
+          acc[key] = [];
+        }
+        acc[key].push({
+          label: image.architectures,
+          value: image.id,
+        });
+        return acc;
+      },
+      {}
+    );
+};
+
+const groupImagesByOS = (images: DownloadableImage[]) => {
+  let imagesByOS: ImagesByOS = {};
 
   images.forEach((image) => {
-    if (!!imagesByName[image.name]) {
-      imagesByName[image.name].push(image);
+    if (!!imagesByOS[image.os]) {
+      imagesByOS[image.os].push(image);
     } else {
-      imagesByName[image.name] = [image];
+      imagesByOS[image.os] = [image];
     }
   });
 
-  Object.keys(imagesByName).forEach((distro) => {
-    imagesByName[distro].sort((a, b) => {
+  Object.keys(imagesByOS).forEach((distro) => {
+    imagesByOS[distro].sort((a, b) => {
       return b.release.localeCompare(a.release);
     });
   });
 
-  return imagesByName;
+  return imagesByOS;
 };
 
-const groupArchesByRelease = (images: ImagesByName) => {
+const groupArchesByRelease = (images: ImagesByOS) => {
   let groupedImages: GroupedImages = {};
 
   Object.keys(images).forEach((distro) => {
@@ -100,30 +130,28 @@ const groupArchesByRelease = (images: ImagesByName) => {
   return groupedImages;
 };
 
-const getInitialState = (images: ImagesByName) => {
-  let initialState: ReleasesWithArches = {};
-
-  Object.keys(images).forEach((distro) => {
-    images[distro].forEach((image) => {
-      if (!initialState[getValueKey(distro, image.release)]) {
-        initialState[getValueKey(distro, image.release)] = [];
-      }
-    });
-  });
-
-  return initialState;
-};
-
 const getValueKey = (distro: string, release: string) =>
   `${distro}-${release}`.replace(".", "-");
 
 const DownloadImages: React.FC = () => {
   const dispatch = useDispatch();
   const ubuntu = useSelector(bootResourceSelectors.ubuntu);
+  const resources = useSelector(bootResourceSelectors.ubuntuResources);
 
-  const [images, setImages] = useState<ImagesByName>({});
+  const sources = ubuntu?.sources || [];
   const [groupedImages, setGroupedImages] = useState<GroupedImages>({});
-  const [initialValues, setInitialValues] = useState<ReleasesWithArches>({});
+  const [syncedImages, setSyncedImages] = useState({});
+
+  const eventErrors = useSelector(bootResourceSelectors.eventErrors);
+  const error = eventErrors.find(
+    (error) =>
+      error.event === BootResourceAction.SAVE_UBUNTU ||
+      error.event === BootResourceAction.STOP_IMPORT
+  )?.error;
+  const cleanup = useCallback(() => bootResourceActions.cleanup(), []);
+
+  const mainSource = sources.length > 0 ? sources[0] : null;
+  const tooManySources = sources.length > 1;
 
   useEffect(() => {
     if (ubuntu) {
@@ -131,12 +159,12 @@ const DownloadImages: React.FC = () => {
         ubuntu.releases,
         ubuntu.arches
       );
-      const imagesByName = groupImagesByName(downloadableImages);
-      setImages(imagesByName);
-      setGroupedImages(groupArchesByRelease(imagesByName));
-      setInitialValues(getInitialState(imagesByName));
+      const syncedImages = getSyncedImages(downloadableImages, resources);
+      setSyncedImages(syncedImages);
+      const imagesByOS = groupImagesByOS(downloadableImages);
+      setGroupedImages(groupArchesByRelease(imagesByOS));
     }
-  }, [ubuntu]);
+  }, [ubuntu, resources]);
 
   useEffect(() => {
     return () => {
@@ -148,77 +176,89 @@ const DownloadImages: React.FC = () => {
 
   const resetForm = () => {
     setSidePanelContent(null);
-    setInitialValues(images ? getInitialState(images) : {});
   };
 
   return (
-    <ContentSection>
-      <>
-        <ContentSection.Content>
-          <Formik
-            enableReinitialize={true}
-            initialValues={initialValues}
-            onSubmit={(values) => console.log(values)}
-          >
-            {({ isSubmitting, dirty, values, setFieldValue }) => (
-              <Form>
-                {Object.keys(groupedImages).map((distro) => (
-                  <span key={distro}>
-                    <h2 className="p-heading--4">{distro} images</h2>
-                    <table className="download-images-table">
-                      <thead>
-                        <tr>
-                          <th>Release</th>
-                          <th>Architecture</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {Object.keys(groupedImages[distro]).map((release) => (
-                          <tr aria-label={release} key={release}>
-                            <td>{release}</td>
-                            <td>
-                              <Field
-                                as={MultiSelect}
-                                items={groupedImages[distro][release]}
-                                name={`${distro}-${release}`}
-                                onItemsUpdate={(items: MultiSelectItem) =>
-                                  setFieldValue(
-                                    getValueKey(distro, release),
-                                    items
-                                  )
-                                }
-                                placeholder="Select architectures"
-                                selectedItems={
-                                  values[getValueKey(distro, release)]
-                                }
-                                variant="condensed"
-                              />
-                            </td>
-                          </tr>
-                        ))}
-                      </tbody>
-                    </table>
-                  </span>
-                ))}
-                <ContentSection.Footer>
-                  <Button appearance="base" onClick={resetForm} type="button">
-                    Cancel
-                  </Button>
-                  <ActionButton
-                    appearance="positive"
-                    disabled={!dirty || isSubmitting}
-                    loading={isSubmitting}
-                    type="submit"
-                  >
-                    Save
-                  </ActionButton>
-                </ContentSection.Footer>
-              </Form>
-            )}
-          </Formik>
-        </ContentSection.Content>
-      </>
-    </ContentSection>
+    <Strip shallow>
+      <FormikForm
+        allowUnchanged
+        buttonsBehavior="independent"
+        cleanup={cleanup}
+        editable={!tooManySources}
+        enableReinitialize
+        errors={error}
+        initialValues={syncedImages}
+        onCancel={resetForm}
+        onSubmit={(values) => {
+          dispatch(cleanup());
+          const osystems = Object.entries(
+            values as Record<string, { label: string; value: string }[]>
+          ).map(([key, images]) => {
+            const [osystem] = key.split("-", 1);
+            const arches = images.map((image) => image.label);
+            const release = images[0].value.split("-")[1];
+            return {
+              arches,
+              osystem: osystem.toLowerCase(),
+              release,
+            };
+          });
+          const params = mainSource
+            ? {
+                osystems,
+                ...mainSource,
+              }
+            : {
+                osystems,
+                source_type: BootResourceSourceType.MAAS_IO,
+              };
+          dispatch(bootResourceActions.saveUbuntu(params));
+          resetForm();
+        }}
+        onSuccess={() => {
+          dispatch(bootResourceActions.poll({ continuous: false }));
+        }}
+        submitLabel={"Download"}
+      >
+        {({ values, setFieldValue }: { values: any; setFieldValue: any }) => (
+          <Form>
+            {Object.keys(groupedImages).map((distro) => (
+              <span key={distro}>
+                <h2 className="p-heading--4">{distro} images</h2>
+                <table className="download-images-table">
+                  <thead>
+                    <tr>
+                      <th>Release</th>
+                      <th>Architecture</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {Object.keys(groupedImages[distro]).map((release) => (
+                      <tr aria-label={release} key={release}>
+                        <td>{release}</td>
+                        <td>
+                          <Field
+                            as={MultiSelect}
+                            items={groupedImages[distro][release]}
+                            name={`${distro}-${release}`}
+                            onItemsUpdate={(items: MultiSelectItem) =>
+                              setFieldValue(getValueKey(distro, release), items)
+                            }
+                            placeholder="Select architectures"
+                            selectedItems={values[getValueKey(distro, release)]}
+                            variant="condensed"
+                          />
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </span>
+            ))}
+          </Form>
+        )}
+      </FormikForm>
+    </Strip>
   );
 };
 

--- a/src/app/images/components/SMImagesTable/DownloadImages/DownloadImages.tsx
+++ b/src/app/images/components/SMImagesTable/DownloadImages/DownloadImages.tsx
@@ -1,0 +1,225 @@
+import React, { useEffect, useState } from "react";
+
+import { ContentSection } from "@canonical/maas-react-components";
+import type { MultiSelectItem } from "@canonical/react-components";
+import {
+  MultiSelect,
+  ActionButton,
+  Button,
+  Form,
+} from "@canonical/react-components";
+import { Field, Formik } from "formik";
+import { useDispatch, useSelector } from "react-redux";
+
+import { useSidePanel } from "@/app/base/side-panel-context";
+import { bootResourceActions } from "@/app/store/bootresource";
+import bootResourceSelectors from "@/app/store/bootresource/selectors";
+import type {
+  BootResourceUbuntuArch,
+  BootResourceUbuntuRelease,
+} from "@/app/store/bootresource/types";
+
+import "./_index.scss";
+
+type GroupedImages = {
+  [key: string]: ReleasesWithArches;
+};
+
+type ReleasesWithArches = {
+  [key: string]: MultiSelectItem[];
+};
+
+type ImagesByName = { [key: string]: DownloadableImage[] };
+
+type DownloadableImage = {
+  id: string;
+  name: string;
+  release: string;
+  architectures: string;
+};
+
+const getDownloadableImages = (
+  releases: BootResourceUbuntuRelease[],
+  architectures: BootResourceUbuntuArch[]
+) => {
+  return releases
+    .map((image) => {
+      return architectures.map((arch) => {
+        return {
+          id: `ubuntu-${image.title}-${arch.name}`,
+          name: "Ubuntu",
+          release: image.title,
+          architectures: arch.name,
+        };
+      });
+    })
+    .flat();
+};
+
+const groupImagesByName = (images: DownloadableImage[]) => {
+  let imagesByName: ImagesByName = {};
+
+  images.forEach((image) => {
+    if (!!imagesByName[image.name]) {
+      imagesByName[image.name].push(image);
+    } else {
+      imagesByName[image.name] = [image];
+    }
+  });
+
+  Object.keys(imagesByName).forEach((distro) => {
+    imagesByName[distro].sort((a, b) => {
+      return b.release.localeCompare(a.release);
+    });
+  });
+
+  return imagesByName;
+};
+
+const groupArchesByRelease = (images: ImagesByName) => {
+  let groupedImages: GroupedImages = {};
+
+  Object.keys(images).forEach((distro) => {
+    if (!groupedImages[distro]) {
+      groupedImages[distro] = {};
+    }
+    images[distro].forEach((image) => {
+      if (!groupedImages[distro][image.release]) {
+        groupedImages[distro][image.release] = [
+          { label: image.architectures.toString(), value: image.id },
+        ];
+      } else {
+        groupedImages[distro][image.release].push({
+          label: image.architectures.toString(),
+          value: image.id,
+        });
+      }
+    });
+  });
+
+  return groupedImages;
+};
+
+const getInitialState = (images: ImagesByName) => {
+  let initialState: ReleasesWithArches = {};
+
+  Object.keys(images).forEach((distro) => {
+    images[distro].forEach((image) => {
+      if (!initialState[getValueKey(distro, image.release)]) {
+        initialState[getValueKey(distro, image.release)] = [];
+      }
+    });
+  });
+
+  return initialState;
+};
+
+const getValueKey = (distro: string, release: string) =>
+  `${distro}-${release}`.replace(".", "-");
+
+const DownloadImages: React.FC = () => {
+  const dispatch = useDispatch();
+  const ubuntu = useSelector(bootResourceSelectors.ubuntu);
+
+  const [images, setImages] = useState<ImagesByName>({});
+  const [groupedImages, setGroupedImages] = useState<GroupedImages>({});
+  const [initialValues, setInitialValues] = useState<ReleasesWithArches>({});
+
+  useEffect(() => {
+    if (ubuntu) {
+      const downloadableImages = getDownloadableImages(
+        ubuntu.releases,
+        ubuntu.arches
+      );
+      const imagesByName = groupImagesByName(downloadableImages);
+      setImages(imagesByName);
+      setGroupedImages(groupArchesByRelease(imagesByName));
+      setInitialValues(getInitialState(imagesByName));
+    }
+  }, [ubuntu]);
+
+  useEffect(() => {
+    return () => {
+      dispatch(bootResourceActions.cleanup());
+    };
+  }, [dispatch]);
+
+  const { setSidePanelContent } = useSidePanel();
+
+  const resetForm = () => {
+    setSidePanelContent(null);
+    setInitialValues(images ? getInitialState(images) : {});
+  };
+
+  return (
+    <ContentSection>
+      <>
+        <ContentSection.Content>
+          <Formik
+            enableReinitialize={true}
+            initialValues={initialValues}
+            onSubmit={(values) => console.log(values)}
+          >
+            {({ isSubmitting, dirty, values, setFieldValue }) => (
+              <Form>
+                {Object.keys(groupedImages).map((distro) => (
+                  <span key={distro}>
+                    <h2 className="p-heading--4">{distro} images</h2>
+                    <table className="download-images-table">
+                      <thead>
+                        <tr>
+                          <th>Release</th>
+                          <th>Architecture</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {Object.keys(groupedImages[distro]).map((release) => (
+                          <tr aria-label={release} key={release}>
+                            <td>{release}</td>
+                            <td>
+                              <Field
+                                as={MultiSelect}
+                                items={groupedImages[distro][release]}
+                                name={`${distro}-${release}`}
+                                onItemsUpdate={(items: MultiSelectItem) =>
+                                  setFieldValue(
+                                    getValueKey(distro, release),
+                                    items
+                                  )
+                                }
+                                placeholder="Select architectures"
+                                selectedItems={
+                                  values[getValueKey(distro, release)]
+                                }
+                                variant="condensed"
+                              />
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </span>
+                ))}
+                <ContentSection.Footer>
+                  <Button appearance="base" onClick={resetForm} type="button">
+                    Cancel
+                  </Button>
+                  <ActionButton
+                    appearance="positive"
+                    disabled={!dirty || isSubmitting}
+                    loading={isSubmitting}
+                    type="submit"
+                  >
+                    Save
+                  </ActionButton>
+                </ContentSection.Footer>
+              </Form>
+            )}
+          </Formik>
+        </ContentSection.Content>
+      </>
+    </ContentSection>
+  );
+};
+
+export default DownloadImages;

--- a/src/app/images/components/SMImagesTable/DownloadImages/DownloadImagesSelect.tsx
+++ b/src/app/images/components/SMImagesTable/DownloadImages/DownloadImagesSelect.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+
+import {
+  Form,
+  MultiSelect,
+  type MultiSelectItem,
+} from "@canonical/react-components";
+import { Field } from "formik";
+
+import type { GroupedImages } from "@/app/images/components/SMImagesTable/DownloadImages/DownloadImages";
+
+type DownloadImagesSelectProps = {
+  values: Record<string, MultiSelectItem[]>;
+  setFieldValue: (key: string, value: MultiSelectItem) => void;
+  groupedImages: GroupedImages;
+};
+
+const getValueKey = (distro: string, release: string) =>
+  `${distro}-${release}`.replace(".", "-");
+
+const DownloadImagesSelect: React.FC<DownloadImagesSelectProps> = ({
+  values,
+  setFieldValue,
+  groupedImages,
+}) => {
+  return (
+    <Form>
+      {Object.keys(groupedImages).map((distro) => (
+        <span key={distro}>
+          <h2 className="p-heading--4">{distro} images</h2>
+          <table className="download-images-table">
+            <thead>
+              <tr>
+                <th>Release</th>
+                <th>Architecture</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Object.keys(groupedImages[distro]).map((release) => (
+                <tr aria-label={release} key={release}>
+                  <td>{release}</td>
+                  <td>
+                    <Field
+                      as={MultiSelect}
+                      items={groupedImages[distro][release]}
+                      name={`${distro}-${release}`}
+                      onItemsUpdate={(items: MultiSelectItem) =>
+                        setFieldValue(getValueKey(distro, release), items)
+                      }
+                      placeholder="Select architectures"
+                      selectedItems={values[getValueKey(distro, release)]}
+                      variant="condensed"
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </span>
+      ))}
+    </Form>
+  );
+};
+
+export default DownloadImagesSelect;

--- a/src/app/images/components/SMImagesTable/DownloadImages/DownloadImagesSelect.tsx
+++ b/src/app/images/components/SMImagesTable/DownloadImages/DownloadImagesSelect.tsx
@@ -1,10 +1,6 @@
 import React from "react";
 
-import {
-  Form,
-  MultiSelect,
-  type MultiSelectItem,
-} from "@canonical/react-components";
+import { MultiSelect, type MultiSelectItem } from "@canonical/react-components";
 import { Field } from "formik";
 
 import type { GroupedImages } from "@/app/images/components/SMImagesTable/DownloadImages/DownloadImages";
@@ -24,7 +20,7 @@ const DownloadImagesSelect: React.FC<DownloadImagesSelectProps> = ({
   groupedImages,
 }) => {
   return (
-    <Form>
+    <>
       {Object.keys(groupedImages).map((distro) => (
         <span key={distro}>
           <h2 className="p-heading--4">{distro} images</h2>
@@ -58,7 +54,7 @@ const DownloadImagesSelect: React.FC<DownloadImagesSelectProps> = ({
           </table>
         </span>
       ))}
-    </Form>
+    </>
   );
 };
 

--- a/src/app/images/components/SMImagesTable/DownloadImages/_index.scss
+++ b/src/app/images/components/SMImagesTable/DownloadImages/_index.scss
@@ -1,0 +1,17 @@
+.download-images-table {
+  border-collapse: separate;
+
+  thead {
+    th:first-child {
+      width: 30%;
+    }
+
+    th:last-child {
+      width: 70%;
+    }
+  }
+
+  td {
+    overflow: visible;
+  }
+}

--- a/src/app/images/components/SMImagesTable/ImagesHeader/ImagesHeader.tsx
+++ b/src/app/images/components/SMImagesTable/ImagesHeader/ImagesHeader.tsx
@@ -1,0 +1,90 @@
+import React, { useEffect } from "react";
+
+import { Button, Icon, Tooltip } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import { useSidePanel } from "@/app/base/side-panel-context";
+import { ImageSidePanelViews } from "@/app/images/constants";
+import { Labels } from "@/app/images/views/ImageList/SyncedImages/SyncedImages";
+import bootResourceSelectors from "@/app/store/bootresource/selectors";
+import type { BootResourceUbuntuSource } from "@/app/store/bootresource/types";
+import { BootResourceSourceType } from "@/app/store/bootresource/types";
+
+const getImageSyncText = (sources: BootResourceUbuntuSource[]) => {
+  if (sources.length === 1) {
+    const mainSource = sources[0];
+    if (mainSource.source_type === BootResourceSourceType.MAAS_IO) {
+      return "maas.io";
+    }
+    return mainSource.url;
+  }
+  return "sources";
+};
+
+const ImagesHeader: React.FC = () => {
+  const ubuntu = useSelector(bootResourceSelectors.ubuntu);
+  const resources = useSelector(bootResourceSelectors.resources);
+  const { setSidePanelContent } = useSidePanel();
+  const sources = ubuntu?.sources || [];
+  const hasSources = sources.length !== 0;
+
+  useEffect(() => {
+    if (!hasSources) {
+      setSidePanelContent({
+        view: ImageSidePanelViews.CHANGE_SOURCE,
+        extras: { hasSources },
+      });
+    }
+  }, [hasSources, setSidePanelContent]);
+
+  const canChangeSource = resources.every((resource) => !resource.downloading);
+  return (
+    <div>
+      <div className="u-flex--between">
+        <h4 data-testid="image-sync-text">
+          {Labels.SyncedFrom} <strong>{getImageSyncText(sources)}</strong>
+        </h4>
+        <div>
+          <Button
+            onClick={() =>
+              setSidePanelContent({
+                view: ImageSidePanelViews.DOWNLOAD_IMAGE,
+              })
+            }
+            type="button"
+          >
+            Download images
+          </Button>
+          <Button
+            data-testid="change-source-button"
+            disabled={!canChangeSource}
+            onClick={() =>
+              setSidePanelContent({
+                view: ImageSidePanelViews.CHANGE_SOURCE,
+                extras: { hasSources },
+              })
+            }
+          >
+            {Labels.ChangeSource}
+            {!canChangeSource && (
+              <Tooltip
+                className="u-nudge-right--small"
+                message="Cannot change source while images are downloading."
+                position="top-right"
+              >
+                <Icon name="information" />
+              </Tooltip>
+            )}
+          </Button>
+        </div>
+      </div>
+      <p>
+        Select images to be imported and kept in sync daily. Images will be
+        available for deploying to machines managed by MAAS.
+      </p>
+      <hr />
+    </div>
+  );
+};
+
+export default ImagesHeader;

--- a/src/app/images/constants.ts
+++ b/src/app/images/constants.ts
@@ -1,6 +1,7 @@
 export const ImageNonActionHeaderViews = {
   CHANGE_SOURCE: ["imageNonActionForm", "changeSource"],
   DELETE_IMAGE: ["imageNonActionForm", "deleteImage"],
+  DOWNLOAD_IMAGE: ["imageNonActionForm", "downloadImage"],
 } as const;
 
 export const ImageSidePanelViews = {

--- a/src/app/images/views/ImageList/ImageList.tsx
+++ b/src/app/images/views/ImageList/ImageList.tsx
@@ -3,10 +3,7 @@ import { useEffect } from "react";
 import { Notification } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
-import CustomImages from "./CustomImages";
-import GeneratedImages from "./GeneratedImages";
 import ImageListHeader from "./ImageListHeader";
-import SyncedImages from "./SyncedImages";
 
 import PageContent from "@/app/base/components/PageContent";
 import { useWindowTitle } from "@/app/base/hooks";
@@ -65,9 +62,9 @@ const ImageList = (): JSX.Element => {
           )}
           {!!ubuntu && <ImagesHeader />}
           <SMImagesTable />
-          {!!ubuntu && <SyncedImages />}
-          <GeneratedImages />
-          <CustomImages />
+          {/*{!!ubuntu && <SyncedImages />}*/}
+          {/*<GeneratedImages />*/}
+          {/*<CustomImages />*/}
         </>
       )}
     </PageContent>

--- a/src/app/images/views/ImageList/ImageList.tsx
+++ b/src/app/images/views/ImageList/ImageList.tsx
@@ -12,6 +12,7 @@ import PageContent from "@/app/base/components/PageContent";
 import { useWindowTitle } from "@/app/base/hooks";
 import { useSidePanel } from "@/app/base/side-panel-context";
 import ImagesForms from "@/app/images/components/ImagesForms";
+import ImagesHeader from "@/app/images/components/SMImagesTable/ImagesHeader/ImagesHeader";
 import SMImagesTable from "@/app/images/components/SMImagesTable/SMImagesTable";
 import { bootResourceActions } from "@/app/store/bootresource";
 import bootResourceSelectors from "@/app/store/bootresource/selectors";
@@ -62,6 +63,7 @@ const ImageList = (): JSX.Element => {
               {Labels.SyncDisabled}
             </Notification>
           )}
+          {!!ubuntu && <ImagesHeader />}
           <SMImagesTable />
           {!!ubuntu && <SyncedImages />}
           <GeneratedImages />

--- a/src/app/images/views/ImageList/SyncedImages/SyncedImages.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/SyncedImages.tsx
@@ -90,16 +90,6 @@ const SyncedImages = ({ ...stripProps }: Props): JSX.Element | null => {
                   </Tooltip>
                 )}
               </Button>
-              <Button
-                onClick={() =>
-                  setSidePanelContent({
-                    view: ImageSidePanelViews.DOWNLOAD_IMAGE,
-                  })
-                }
-                type="button"
-              >
-                Download images
-              </Button>
             </div>
             <p>
               Select images to be imported and kept in sync daily. Images will

--- a/src/app/images/views/ImageList/SyncedImages/SyncedImages.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/SyncedImages.tsx
@@ -90,6 +90,16 @@ const SyncedImages = ({ ...stripProps }: Props): JSX.Element | null => {
                   </Tooltip>
                 )}
               </Button>
+              <Button
+                onClick={() =>
+                  setSidePanelContent({
+                    view: ImageSidePanelViews.DOWNLOAD_IMAGE,
+                  })
+                }
+                type="button"
+              >
+                Download images
+              </Button>
             </div>
             <p>
               Select images to be imported and kept in sync daily. Images will

--- a/src/app/store/utils/node/base.ts
+++ b/src/app/store/utils/node/base.ts
@@ -210,6 +210,7 @@ const sidePanelTitleMap: Record<string, string> = {
   [SidePanelViews.DELETE_SPECIAL_FILESYSTEM[1]]: "Delete special filesystem",
   [SidePanelViews.DeleteTag[1]]: "Delete tag",
   [SidePanelViews.DELETE_VOLUME_GROUP[1]]: "Delete volume group",
+  [SidePanelViews.DOWNLOAD_IMAGE[1]]: "Download image",
   [SidePanelViews.EDIT_INTERFACE[1]]: "Edit interface",
   [SidePanelViews.CREATE_ZONE[1]]: "Add AZ",
   [SidePanelViews.EDIT_DISK[1]]: "Edit disk",


### PR DESCRIPTION
## Done
- Replicated the "Download images" form UI from MAAS Site Manager
- Added table header for the Images view, containing the "Download images" and "Cahge source" buttons
- Integrated the MAAS dispatch calls for both Ubuntu and Non-Ubuntu images

https://warthogs.atlassian.net/browse/MAASENG-4204

## Notes

"Stop import" button functionality is not fully implemented. Stopping imports does not removed the "stopped" images from the table, and does not correctly revert the button to "Download images".